### PR TITLE
eepmake produces random gpio settings

### DIFF
--- a/eepromutils/eepmake.c
+++ b/eepromutils/eepmake.c
@@ -432,13 +432,13 @@ int read_text(char* in) {
 	
 	vinf_atom.type = ATOM_VENDOR_TYPE;
 	vinf_atom.count = ATOM_VENDOR_NUM;
-	vinf = (struct vendor_info_d *) malloc(sizeof(struct vendor_info_d));
+	vinf = (struct vendor_info_d *) calloc(1, sizeof(struct vendor_info_d));
 	vinf_atom.data = (char *)vinf;
 	vinf_atom.dlen = VENDOR_SIZE + CRC_SIZE;
 	
 	gpio_atom.type = ATOM_GPIO_TYPE;
 	gpio_atom.count = ATOM_GPIO_NUM;
-	gpiomap = (struct gpio_map_d *) malloc(sizeof(struct gpio_map_d));
+	gpiomap = (struct gpio_map_d *) calloc(1, sizeof(struct gpio_map_d));
 	gpio_atom.data = (char *)gpiomap;
 	gpio_atom.dlen = GPIO_SIZE + CRC_SIZE;
 	


### PR DESCRIPTION
This issue was initially reported in Jan, 2016 in #31.

The eeprom images generated by the eepmake utility are not reproducable
because malloc does not zero memory.

Here are the test settings, notice we are not using a random UUID:
```
product_uuid 3d8ae6eb-a8d9-46de-b146-000131ec6f4f
product_id 0x2355
product_ver 0x4242
vendor "ACME Technology Company Inc."
product "thing thing thing thing thing thing"
gpio_drive 5
gpio_slew 0
gpio_hysteresis 0
back_power 0
setgpio  23    INPUT     DEFAULT
```

Doing a repeated run of eepmake returns various outputs:

```
hats/eepromutils$ for i in {1..1000} ; do ./eepmake test_settings.txt /dev/stdout  | md5 ; done | sort | uniq -c
  72 044bc71dbba6d3d5919ba66da6ff6ee6
  69 13ad0f9330f719eeb26040b4b0ccf460
  62 17471ed3398abe5551cec1f6256715a3
  60 2b16f6deb88579049b380f81ce7bb3bf
  61 5ddad34b7a5519820dd14a96055bdc38
  58 6844f91b475606d2ff0e8b79bb1be60c
  60 77c530dacbe72c96cfcde0b2e228fd5d
  49 9591b1ebdb364c1e1ad4639882eaad65
  50 9dfbbe7c88eb1897671f99f111474436
  50 b530276a7009d33379217d3c3135673b
  67 b8b216cab38413b4b2641919be4b08fd
  66 c78ef9ac84e80cd869c3c1f01e38926c
  86 c7b6c89e05ffba0b2c64c1cb0938371b
  68 cbe160606ef19bdbb1409da87102d27d
  65 cf28ac87eb66d4f432f3383f356f5c9b
   5 e5a34f41dd5cf6cf750c39883a19e6d7
   1 f05dcce30d43939f4d5ec04944208080
  51 fbdb2d8e7982f17d4b3b39ff6b419aba
```

Not zeroing the memory has some bad side effects, such as randomly setting gpio pins:

```
hats/eepromutils$ for i in {1..10} ; do ./eepmake test_settings.txt test.$i ; ./eepdump test.$i dump.$i ; done
...
hats/eepromutils$ grep setgpio dump* | grep -v "23      INPUT     DEFAULT"
dump.10:setgpio  5      INPUT     NONE
dump.10:setgpio  13      INPUT     NONE
dump.5:setgpio  5      INPUT     DOWN
dump.5:setgpio  13      INPUT     DOWN
dump.6:setgpio  5      INPUT     UP
dump.6:setgpio  13      INPUT     UP
dump.7:setgpio  5      INPUT     UP
dump.7:setgpio  13      INPUT     UP
dump.8:setgpio  5      INPUT     DOWN
dump.8:setgpio  13      INPUT     DOWN
dump.9:setgpio  5      INPUT     UP
dump.9:setgpio  13      INPUT     UP
```

After the changes in this commit (changing two key malloc calls to
calloc), the results are again deterministic:

```
hats/eepromutils$ for i in {1..1000} ; do ./eepmake test_settings.txt /dev/stdout  | md5 ; done | sort | uniq -c
1000 e5a34f41dd5cf6cf750c39883a19e6d7
```