### PR TITLE
custom_data in eeprom_settings.txt causes a segfault

### DIFF
--- a/eepromutils/eepmake.c
+++ b/eepromutils/eepmake.c
@@ -167,6 +167,7 @@ void parse_data(char* c) {
 
 void finish_data() {
 	if (data_receive) {
+		data_receive = false;
 		*data = (char *) realloc(*data, data_len);
 			
 		total_size+=ATOM_SIZE+data_len;

--- a/eepromutils/eeprom_settings.txt
+++ b/eepromutils/eeprom_settings.txt
@@ -30,6 +30,10 @@ vendor "ACME Technology Company"
 # ASCII product string (max 255 characters)
 product "Special Sensor Board"
 
+# Custom binary data
+custom_data
+c0ffee
+end
 
 ########################################################################
 # GPIO bank settings, set to nonzero to change from the default.


### PR DESCRIPTION
The custom_data command is not well documented.  Through a reading
of eepmake.c, it was clear that it was possible to include custom
data in the eeprom_settings.txt file, but the format was not clear.
Once I figured out the format, I found that eepmake would segfault:

```
hats/eepromutils$ ./eepmake eeprom_settings.txt /dev/null
Opening file eeprom_settings.txt for read
UUID=71b07c8e-10fe-472c-b24a-906f5301fb4e
Done reading
Writing out...
eepmake(99370,0x7fffacf01380) malloc: *** error for object 0x7fe3c6c02818: incorrect checksum for freed object - object was probably modified after being freed.
*** set a breakpoint in malloc_error_break to debug
Abort trap: 6
```

This is because the data_receive flag is never set back to false.
There is a final call to finish_data() in read_text(), which I think
is there to allow long custom data or device tree blobs to be tacked
onto the end of the file without an "end" command.  However, since
data_receive was not being set to false, finish_data() is run fully
twice.  This results in a count of two custom atoms when there is
only one.  eepmake crashes when trying to write out the second,
non-existant custom atom.

I've added a small example to the eeprom_settings.txt to show
the custom_data command.