### PR TITLE
eepflash.sh: remove references to rpi-update

### DIFF
--- a/eepromutils/eepflash.sh
+++ b/eepromutils/eepflash.sh
@@ -19,12 +19,12 @@ usage()
 	echo "	-a= --address= i2c eeprom address"
 	echo "	-t=eeprom_type --type=eeprom_type: eeprom type to use"
 	echo "		We support the following eeprom types:"
-	echo "		-24c32"
-	echo "		-24c64"
-	echo "		-24c128"
-	echo "		-24c256"
-	echo "		-24c512"
-	echo "		-24c1024"
+	echo "		    24c32"
+	echo "		    24c64"
+	echo "		    24c128"
+	echo "		    24c256"
+	echo "		    24c512"
+	echo "		    24c1024"
 	echo ""
 	echo "Example:"
 	echo "./eepflash -w -f=crex0.1.eep -t=24c32 -d=1 -a=57"
@@ -111,7 +111,7 @@ if [ "$BUS" = "NOT_SET" ]; then
 		dtoverlay i2c-gpio i2c_gpio_sda=0 i2c_gpio_scl=1
 		rc=$?
 		if [ $rc != 0 ]; then
-			echo "Loading of i2c-gpio dtoverlay failed. Do an rpi-update (and maybe apt-get update; apt-get upgrade)."
+			echo "Loading of i2c-gpio dtoverlay failed."
 			exit $rc
 		fi
 		if [ -e "/dev/i2c-3" ]; then
@@ -130,7 +130,7 @@ modprobe at24
 
 rc=$?
 if [ $rc != 0 ]; then
-	echo "Modprobe of at24 failed. Do an rpi-update."
+	echo "Modprobe of at24 failed."
 	exit $rc
 fi
 


### PR DESCRIPTION
Also remove minus signs from in front of EEPROM types in usage message, since they should be specified without a minus sign.