### PR TITLE
eepmake: Fix parse_data sscanf

### DIFF
--- a/eepromutils/eepmake.c
+++ b/eepromutils/eepmake.c
@@ -155,7 +155,7 @@ void parse_data(char* c) {
 				*data = (char *) realloc(*data, data_cap);
 			}
 			
-			sscanf(c, "%2x", (unsigned int *)*data+data_len++);
+			sscanf(c, "%2hhX", (unsigned char *)*data+data_len++);
 			
 			*(c+2) = s;
 			c+=2;


### PR DESCRIPTION
`%2X` format string reads `sizeof(int)` bytes, but only 2 hexadecimal characters are supplied by `c` pointer which is 1 byte long.
Using `%2hhX` tells sscanf to read sizeof(char) bytes or 1 byte.

On system where sizeof(int) == sizeof(char) this is no issue but on other ones, the arithmetic operation `(unsigned int*)*data+data_len++` is increasing the pointer sizeof(int) bytes instead instead of 1 byte.