### PR TITLE
Allows eepdump and eepmake to be compiled on Mac OS

### DIFF
--- a/eepromutils/eepdump.c
+++ b/eepromutils/eepdump.c
@@ -3,7 +3,14 @@
 #include <ctype.h>
 #include <string.h>
 #include <stdbool.h>
-#include <endian.h>
+
+#ifndef __APPLE__
+	#include <endian.h>
+#else
+	#include <libkern/OSByteOrder.h>
+	#define htobe32(x) OSSwapHostToBigInt32(x)
+	#define be32toh(x) OSSwapBigToHostInt32(x)
+#endif
 
 #include "eeptypes.h"
 

--- a/eepromutils/eepmake.c
+++ b/eepromutils/eepmake.c
@@ -11,6 +11,14 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+#ifndef __APPLE__
+	#include <endian.h>
+#else
+	#include <libkern/OSByteOrder.h>
+	#define htole32(x) OSSwapHostToLittleInt32(x)
+	#define be32toh(x) OSSwapBigToHostInt32(x)
+#endif
+
 #include "eeptypes.h"
 
 //todo: larger initial mallocs


### PR DESCRIPTION
Mac OS X doesn't provide `endian.h`.
It's only required for the `be32toh` and `htobe32` utility functions.
Mac OS X provides similare functions in `libkern/OSByteOrder.h`.

Respectively `OSSwapHostToBigInt32` for `htobe32` and `OSSwapBigToHostInt32` for `be32toh`.

This adds a preprocessor condition to include `endian.h` on non apple system and to include `libkern/OSByteOrder.h` as well as defining to macro to provide `htobe32` and `be32toh` on apple plateform.