### PR TITLE
eepmake: add missing include for endian.h

### DIFF
--- a/eepromutils/eepmake.c
+++ b/eepromutils/eepmake.c
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <endian.h>
 
 #include "eeptypes.h"
 


### PR DESCRIPTION
Signed-off-by: Michael Heimpold <mhei@heimpold.de>