### PR TITLE
eepflash.sh: two minor improvements

### DIFF
--- a/eepromutils/eepflash.sh
+++ b/eepromutils/eepflash.sh
@@ -142,23 +142,27 @@ if [ ! -d "$SYS/$BUS-00$ADDR" ]; then
 	echo "$TYPE 0x$ADDR" > $SYS/new_device
 fi
 
-DD_VERSION=$(dd --version | grep coreutils | sed -e 's/\.//' | cut -d' ' -f 3)
-if [ $DD_VERSION -ge 824 ]
- then
-	DD_STATUS="progress"
- else
-	DD_STATUS="none"
+DD_VERSION=$(dd --version 2>&1 | grep coreutils | sed -e 's/\.//' | cut -d' ' -f 3)
+if [ -z "$DD_VERSION" ]; then
+	# probably busybox's dd
+	DD_STATUS=""
+else
+	if [ $DD_VERSION -ge 824 ]; then
+		DD_STATUS="status=progress"
+	else
+		DD_STATUS="status=none"
+	fi
 fi
 
 if [ "$MODE" = "write" ]
  then
 	echo "Writing..."
-	dd if="$FILE" of=$SYS/$BUS-00$ADDR/eeprom status=$DD_STATUS
+	dd if="$FILE" of=$SYS/$BUS-00$ADDR/eeprom $DD_STATUS
 	rc=$?
 elif [ "$MODE" = "read" ]
  then
 	echo "Reading..."
-	dd if=$SYS/$BUS-00$ADDR/eeprom of="$FILE" status=$DD_STATUS
+	dd if=$SYS/$BUS-00$ADDR/eeprom of="$FILE" $DD_STATUS
 	rc=$?
 fi
 

--- a/eepromutils/eepflash.sh
+++ b/eepromutils/eepflash.sh
@@ -91,6 +91,10 @@ elif [ "$TYPE" = "NOT_SET" ]; then
 	exit 1
 fi
 
+if [ "$ADDR" = "NOT_SET" ]; then
+	ADDR=50
+fi
+
 echo "This will attempt to talk to an eeprom at i2c address 0x$ADDR on bus $BUS. Make sure there is an eeprom at this address."
 echo "This script comes with ABSOLUTELY no warranty. Continue only if you know what you are doing."
 
@@ -122,10 +126,6 @@ if [ "$BUS" = "NOT_SET" ]; then
 			echo "Expected I2C bus (i2c-9) not found."
 		fi
 	fi
-fi
-
-if [ "$ADDR" = "NOT_SET" ]; then
-	ADDR=50
 fi
 
 modprobe at24


### PR DESCRIPTION
This PR improves the warning message when user does not give an explicit I2C address on command line by populating the default earlier in the corresponding variable.

The second change allows to use the script on systems without the "big" coreutils dd: for example busybox dd's implementation often has no compiled-in support for the "status" parameter, so just to use it in this case at all.
