### PR TITLE
Fix buffer overflow in custom_atom

### DIFF
--- a/eepromutils/eepmake.c
+++ b/eepromutils/eepmake.c
@@ -609,6 +609,11 @@ int main(int argc, char *argv[]) {
 
 	if (custom_o)
 		for (i = custom_o; i<argc; i++) {
+			if (custom_cap == custom_ct) {
+				custom_cap *= 2;
+				custom_atom = (struct atom_t *)realloc(
+					custom_atom, custom_cap * sizeof(struct atom_t));
+			}
 			//new custom data file
 			ret = read_custom(argv[i]);
 			if (ret) {


### PR DESCRIPTION
If a custom file is added with the -c option no additional memory is
reserved. Thus read_custom() writes over the reserved memory.
To reproduce the issue the following eepmake call is sufficient:
./eepmake eeprom_settings.txt out.eep custom.bin

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>