### PR TITLE
Add bank1 support

### DIFF
--- a/eepromutils/eeprom_settings.txt
+++ b/eepromutils/eeprom_settings.txt
@@ -92,3 +92,30 @@ back_power 0
 #setgpio  25    INPUT     DEFAULT
 #setgpio  26    INPUT     DEFAULT
 #setgpio  27    INPUT     DEFAULT
+
+########################################################################
+# Settings for bank 1 (only valid for CM1/3/3+/4S). Setting one or more of
+# these GPIOs requires setting of drive, slew and hysteresis for bank 1.
+
+# bank1_gpio_drive 0
+# bank1_gpio_slew 0
+# bank1_gpio_hysteresis 0
+
+#setgpio  28    INPUT     DEFAULT
+#setgpio  29    INPUT     DEFAULT
+#setgpio  30    INPUT     DEFAULT
+#setgpio  31    INPUT     DEFAULT
+#setgpio  32    INPUT     DEFAULT
+#setgpio  33    INPUT     DEFAULT
+#setgpio  34    INPUT     DEFAULT
+#setgpio  35    INPUT     DEFAULT
+#setgpio  36    INPUT     DEFAULT
+#setgpio  37    INPUT     DEFAULT
+#setgpio  38    INPUT     DEFAULT
+#setgpio  39    INPUT     DEFAULT
+#setgpio  40    INPUT     DEFAULT
+#setgpio  41    INPUT     DEFAULT
+#setgpio  42    INPUT     DEFAULT
+#setgpio  43    INPUT     DEFAULT
+#setgpio  44    INPUT     DEFAULT
+#setgpio  45    INPUT     DEFAULT

--- a/eepromutils/eeptypes.h
+++ b/eepromutils/eeptypes.h
@@ -6,6 +6,7 @@
 #define ATOM_GPIO_TYPE      0x0002
 #define ATOM_DT_TYPE        0x0003
 #define ATOM_CUSTOM_TYPE    0x0004
+#define ATOM_GPIO_BANK1_TYPE 0x0005
 #define ATOM_HINVALID_TYPE  0xffff
 
 #define ATOM_VENDOR_NUM     0x0000
@@ -17,10 +18,13 @@
 #define ATOM_SIZE   10
 #define VENDOR_SIZE 22
 #define GPIO_SIZE   30
+#define GPIO_BANK1_SIZE 20
 #define CRC_SIZE     2
 
 #define GPIO_MIN     2
-#define GPIO_COUNT  28
+#define GPIO_COUNT        28
+#define GPIO_COUNT_BANK1  18
+#define GPIO_COUNT_TOTAL  (GPIO_COUNT + GPIO_COUNT_BANK1)
 
 #define FORMAT_VERSION 0x01
 


### PR DESCRIPTION
This PR adds support for bank 1 (slew, drive, hysteresis and GPIO settings) as discussed by P.Rosenberger and P.Elwell. It includes the changes in PR "eeprom-format: Add support to configure GPIO bank 1" and thus makes that PR obsolete.